### PR TITLE
chat-space_API

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,46 @@
+$(function(){
+  function buildHTML(message){
+  image = ( message.image ) ? `<img class= "lower-message__image" src=${message.image} >` : "";
+  let html = `<div class=message>
+                <div class="upper-info">
+                  <div class="upper-info__talker">
+                    ${message.user_name}
+                  </div>
+                  <div class="upper-info__date">
+                    ${message.date}
+                  </div>
+                </div>
+                <div class="message__text">
+                  <p class="message__text__content">
+                    ${message.content}
+                  </p>
+                    ${image}
+                </div>
+              </div> `
+              $('.messages').append(html); 
+            }
+
+    $('.new_message').on('submit', function(e){
+      e.preventDefault()
+      let formData = new FormData(this);
+      let url = $(this).attr('action')
+      $.ajax({
+        url: url,  //同期通信でいう『パス』
+        type: 'POST',  //同期通信でいう『HTTPメソッド』
+        data: formData,  
+        dataType: 'json',
+        processData: false,
+        contentType: false
+      })
+      .done(function(data){
+        buildHTML(data);
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+          $('form')[0].reset();
+        })
+        .fail(function(){
+          alert('error');
+        });
+        return false;
+      })
+      
+})

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,8 +8,11 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    if @message.save #メッセージが保存されたら
+      respond_to do |format| #htmlかjsonに条件分岐
+        format.html { redirect_to "group_messages_path(params[:group_id])" }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.id @message.id
+json.content @message.content 
+json.user_name @message.user.name
+json.image @message.image.url
+json.date @message.created_at.strftime("%Y/%m/%d %H:%M") #時間を文字列に変換


### PR DESCRIPTION
#WHAT
chat-space非同期通信の作成
#WHY
chat-spaceのチャット欄の表示を非同期通信によってページを更新することなく
送ったチャットが表示されるようにするため